### PR TITLE
Fix write-single-coil.ts incorrect processing of true value #338

### DIFF
--- a/src/response/write-single-coil.ts
+++ b/src/response/write-single-coil.ts
@@ -53,8 +53,12 @@ export default class WriteSingleCoilResponseBody extends ModbusWriteResponseBody
   constructor (address: number, value: 0 | 0xff00 | boolean) {
     super(FC.WRITE_SINGLE_COIL)
     this._address = address
-
-    this._value = value === 0xFF00 ? 0xFF00 : 0x0000
+    
+    if (value === true || value === 0xFF00) {
+        this._value = 0xFF00
+    } else {
+        this._value = 0x0000
+    }
   }
 
   public createPayload () {


### PR DESCRIPTION
The WriteSingleCoilResponseBody constructor declares that it can handle `boolen` but it can not do that. So I have addled  boolean handling into the function.